### PR TITLE
fixed potential unicode encoding error

### DIFF
--- a/gitless/cli/pprint.py
+++ b/gitless/cli/pprint.py
@@ -37,7 +37,7 @@ def puts(s='', newline=True, stream=sys.stdout.write):
       isinstance(s, unicode) or isinstance(s, colored.ColoredString))
 
   if IS_PY2:
-    s = s.encode(ENCODING)
+    s = s.encode(ENCODING, errors='ignore')
   clint_puts(s, newline=newline, stream=stream)
 
 


### PR DESCRIPTION
Without the `errors='ignore'` flag on `str.encode()`, there seem to be errors when trying to output to environments that don't support unicode.

I believe this commit would fix the error brought up in [this issue](https://github.com/sdg-mit/gitless/issues/52).

This came up when I was trying to write a homebrew formula that would install gitless. Test cases in formulas don't seem to handle unicode output automatically.