### PR TITLE
The `color.ui` setting isn't a boolean

### DIFF
--- a/gitless/cli/gl.py
+++ b/gitless/cli/gl.py
@@ -36,7 +36,8 @@ URL = 'http://gitless.com'
 repo = None
 try:
   repo = core.Repository()
-  colored.DISABLE_COLOR = not repo.config.get_bool('color.ui')
+  colored.DISABLE_COLOR = (repo.config['color.ui'] in
+                           ['false', '0', 'off', 'no', 'never'])
 except (core.NotInRepoError, KeyError):
   pass
 


### PR DESCRIPTION
The `color.ui` setting can not only have boolean values, but also values
like `never`, `always` or `auto`. Hence the check for color needs to be
expanded, else if it is set to `auto` it would lead to an error like:

    $ python gl.py -h
    Traceback (most recent call last):
      File "gl.py", line 10, in <module>
        from gitless.cli import gl
      File "/home/vmx/src/python/gitless/gitless/gitless/cli/gl.py", line 39, in <module>
        colored.DISABLE_COLOR = not repo.config.get_bool('color.ui')
      File "/usr/lib/python2.7/dist-packages/pygit2/config.py", line 199, in get_bool
        check_error(err)
      File "/usr/lib/python2.7/dist-packages/pygit2/errors.py", line 64, in check_error
        raise GitError(message)
    _pygit2.GitError: Failed to parse 'auto' as a boolean value

This fixes #42.