### PR TITLE
Treat pager and editor as commands with arguments

### DIFF
--- a/gitless/cli/commit_dialog.py
+++ b/gitless/cli/commit_dialog.py
@@ -12,6 +12,7 @@ from locale import getpreferredencoding
 import os
 import subprocess
 import sys
+import shlex
 
 
 from . import pprint
@@ -68,8 +69,11 @@ def _launch_editor(fp, repo):
   except KeyError:
     editor = os.environ['EDITOR'] if 'EDITOR' in os.environ else 'vim'
 
+  cmd = shlex.split(editor)
+  cmd.append(fp)
+
   try:
-    ret = subprocess.call([editor, fp])
+    ret = subprocess.call(cmd)
     if ret != 0:
       pprint.err('Call to editor {0} failed'.format(editor))
   except OSError:

--- a/gitless/cli/helpers.py
+++ b/gitless/cli/helpers.py
@@ -11,6 +11,7 @@ import argparse
 import os
 import subprocess
 import sys
+import shlex
 
 from gitless import core
 
@@ -72,7 +73,11 @@ def page(fp, repo):
     pager = repo.config['core.pager']
   except KeyError:
     pass
-  cmd = [pager, fp] if pager else ['less', '-r', '-f', fp]
+  if pager:
+    cmd = shlex.split(pager)
+    cmd.append(fp)
+  else:
+    cmd = ['less', '-r', '-f', fp]
   subprocess.call(cmd, stdin=sys.stdin, stdout=sys.stdout)
 
 


### PR DESCRIPTION
These commands obtained from `~/.gitconfig` or `$EDITOR` may contain spaces and need to be treated accordingly.

Closes #64.