### PR TITLE
Improve the invocation of the pager.

### DIFF
--- a/gitless/cli/helpers.py
+++ b/gitless/cli/helpers.py
@@ -73,11 +73,11 @@ def page(fp, repo):
     pager = repo.config['core.pager']
   except KeyError:
     pass
-  if pager:
-    cmd = shlex.split(pager)
-    cmd.append(fp)
-  else:
-    cmd = ['less', '-r', '-f', fp]
+  pager = pager or os.environ.get('PAGER', None) or 'less'
+  cmd = shlex.split(pager)
+  if os.path.basename(cmd[0]) == 'less':
+    cmd.extend(['-r', '-f'])
+  cmd.append(fp)
   subprocess.call(cmd, stdin=sys.stdin, stdout=sys.stdout)
 
 


### PR DESCRIPTION
Also check for the PAGER environment variable.
Add the -f and -r arguments if the user-specified pager is "less", too.

Thanks for writing and maintaining Gitless!

G'luck,
Peter
