### PR TITLE
Fix an infinite readline() loop.

### DIFF
--- a/gitless/cli/commit_dialog.py
+++ b/gitless/cli/commit_dialog.py
@@ -86,7 +86,7 @@ def _extract_msg(repo):
   sep = pprint.SEP + '\n'
   msg = ''
   l = cf.readline()
-  while l != sep:
+  while l != sep and len(l) > 0:
     msg += l
     l = cf.readline()
   # We reached the separator, this marks the end of the commit msg


### PR DESCRIPTION
At least I am in the habit of removing the boilerplate text, just so
that I'm absolutely sure that the commit message won't contain
anything other than what I've written (e.g. if I accidentally deleted
a character or two from the boilerplate text).  Thus, the end of
the commit message may be reached before the separator is found.

Thanks for writing and maintaining Gitless!

G'luck,
Peter
