### PR TITLE
Make `switch` command a bit more helpful

### DIFF
--- a/gitless/cli/gl_switch.py
+++ b/gitless/cli/gl_switch.py
@@ -30,6 +30,7 @@ def main(args, repo):
   if not b:
     pprint.err('Branch {0} doesn\'t exist'.format(args.branch))
     pprint.err_exp('to list existing branches do gl branch')
+    pprint.err_exp('to create a new branch do gl branch -c feature/foo')
     return False
 
   repo.switch_current_branch(b, move_over=args.move_over)

--- a/gitless/cli/gl_switch.py
+++ b/gitless/cli/gl_switch.py
@@ -30,7 +30,7 @@ def main(args, repo):
   if not b:
     pprint.err('Branch {0} doesn\'t exist'.format(args.branch))
     pprint.err_exp('to list existing branches do gl branch')
-    pprint.err_exp('to create a new branch do gl branch -c feature/foo')
+    pprint.err_exp('to create a new branch do gl branch -c {0}'.format(args.branch))
     return False
 
   repo.switch_current_branch(b, move_over=args.move_over)


### PR DESCRIPTION
fixes #128 

`./setup.py test` returns `Ran 111 tests in 351.188s`, then `OK` and then many of these:
```
Exception AttributeError: "'NoneType' object has no attribute 'git_remote_free'" in 
<bound method Remote.__del__ of <pygit2.remote.Remote object at 0x10b6a5850
>> ignored
````
![](http://i0.kym-cdn.com/photos/images/masonry/000/665/819/b7b.jpg)

I guess Travis will tell...