### PR TITLE
Add Python 3.6 and remove 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: python
 
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
   - "pypy-5.3.1"
 
 env: LIBGIT2=~/libgit2/_install/ LD_LIBRARY_PATH=~/libgit2/_install/lib


### PR DESCRIPTION
3.2 is too old, really