### PR TITLE
Fix AppVeyor - add Scripts to path for current Python

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,7 +33,10 @@ before_test:
 
 test_script:
   - ps: |
+      # e2e tests require `gl` binary
       &$env:PYTHON -m pip install .
+      # 'gl' is installed in Python Scripts directory
+      $env:PATH += ";$(Split-Path $env:PYTHON)\Scripts"
       &$env:PYTHON setup.py nosetests --logging-level=WARN --with-xunit 
       if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
       # upload results to AppVeyor


### PR DESCRIPTION
Tests are failing, because only Python 2.7 is present in PATH