### PR TITLE
Remove warning, "No dst branch specified, using upstream branch..."

### DIFF
--- a/gitless/cli/helpers.py
+++ b/gitless/cli/helpers.py
@@ -61,8 +61,6 @@ def get_branch_or_use_upstream(branch_name, arg, repo):
           'branch set'.format(arg))
 
     ret = current_b.upstream
-    pprint.warn(
-        'No {0} branch specified, using upstream branch {1}'.format(arg, ret))
   else:
     ret = get_branch(branch_name, repo)
   return ret


### PR DESCRIPTION
Resolves #164 by removing the message altogether.

Rationale: This warning is given when a user follows the "happy path"; they've set up an upstream remote, and are using the basic invocation of `publish`:

```bash
$ gl publish
! No dst branch specified, using upstream branch XXX/YYY
```

As a general rule, we shouldn't **warn** the user that we're doing as they've instructed. And in this case, informational messages follow, so we don't need to do that here either. The right choice is to remove this message altogether.