### PR TITLE
Patch test_e2e.py for easier command override

### DIFF
--- a/gitless/tests/test_e2e.py
+++ b/gitless/tests/test_e2e.py
@@ -14,11 +14,12 @@ import time
 
 import sys
 if sys.platform != 'win32':
-  from sh import ErrorReturnCode, gl, git
+  from sh import ErrorReturnCode, Command
 else:
   from pbs import ErrorReturnCode, Command
-  gl = Command('gl')
-  git = Command('git')
+
+gl = Command('gl')
+git = Command('git')
 
 
 from gitless.tests import utils


### PR DESCRIPTION
Binary name in snap is now `gitless.gl` and to run e2e tests
with, the `sh` invocation syntax should be changed for dot

https://amoffat.github.io/sh/sections/faq.html#how-do-i-execute-a-program-with-a-special-character-in-its-name