### PR TITLE
Added the -o and -e flags for the gl init command.

### DIFF
--- a/gitless/cli/gl_init.py
+++ b/gitless/cli/gl_init.py
@@ -25,6 +25,13 @@ def parser(subparsers, _):
       help=(
           'an optional remote repo address from where to read to create the '
           'local repo'))
+  init_parser.add_argument(
+      '-o', '--only', nargs='*',
+      help='use only files given (tracked modified or untracked)', dest='only')
+  init_parser.add_argument(
+      '-e', '--exclude', nargs='+',
+      help = 'use everything but these branches', dest='exclude')
+
   init_parser.set_defaults(func=main)
 
 
@@ -32,7 +39,7 @@ def main(args, repo):
   if repo:
     pprint.err('You are already in a Gitless repository')
     return False
-  core.init_repository(url=args.repo)
+  core.init_repository(url=args.repo, exclude=frozenset(args.exclude if args.exclude else []), only=frozenset(args.only if args.only else []))
   pprint.ok('Local repo created in {0}'.format(os.getcwd()))
   if args.repo:
     pprint.ok('Initialized from remote {0}'.format(args.repo))

--- a/gitless/cli/gl_init.py
+++ b/gitless/cli/gl_init.py
@@ -39,9 +39,9 @@ def main(args, repo):
   if repo:
     pprint.err('You are already in a Gitless repository')
     return False
-  core.init_repository(url=args.repo, 
-        exclude=frozenset(args.exclude if args.exclude else []),
-        only=frozenset(args.only if args.only else []))
+  core.init_repository(url=args.repo,
+        only=frozenset(args.only if args.only else []),
+        exclude=frozenset(args.exclude if args.exclude else []))
   pprint.ok('Local repo created in {0}'.format(os.getcwd()))
   if args.repo:
     pprint.ok('Initialized from remote {0}'.format(args.repo))

--- a/gitless/cli/gl_init.py
+++ b/gitless/cli/gl_init.py
@@ -26,11 +26,11 @@ def parser(subparsers, _):
           'an optional remote repo address from where to read to create the '
           'local repo'))
   init_parser.add_argument(
-      '-o', '--only', nargs='*',
+      '-o', '--only', nargs='+',
       help='use only branches given from remote repo', dest='only')
   init_parser.add_argument(
       '-e', '--exclude', nargs='+',
-      help = 'use everything but this branches from remote repo', dest='exclude')
+      help='use everything but this branches from remote repo', dest='exclude')
 
   init_parser.set_defaults(func=main)
 

--- a/gitless/cli/gl_init.py
+++ b/gitless/cli/gl_init.py
@@ -30,7 +30,7 @@ def parser(subparsers, _):
       help='use only branches given from remote repo', dest='only')
   init_parser.add_argument(
       '-e', '--exclude', nargs='+',
-      help='use everything but this branches from remote repo', dest='exclude')
+      help='use everything but these branches from remote repo', dest='exclude')
 
   init_parser.set_defaults(func=main)
 

--- a/gitless/cli/gl_init.py
+++ b/gitless/cli/gl_init.py
@@ -27,10 +27,10 @@ def parser(subparsers, _):
           'local repo'))
   init_parser.add_argument(
       '-o', '--only', nargs='*',
-      help='use only files given (tracked modified or untracked)', dest='only')
+      help='use only branches given from remote repo', dest='only')
   init_parser.add_argument(
       '-e', '--exclude', nargs='+',
-      help = 'use everything but these branches', dest='exclude')
+      help = 'use everything but this branches from remote repo', dest='exclude')
 
   init_parser.set_defaults(func=main)
 
@@ -39,7 +39,9 @@ def main(args, repo):
   if repo:
     pprint.err('You are already in a Gitless repository')
     return False
-  core.init_repository(url=args.repo, exclude=frozenset(args.exclude if args.exclude else []), only=frozenset(args.only if args.only else []))
+  core.init_repository(url=args.repo, 
+        exclude=frozenset(args.exclude if args.exclude else []),
+        only=frozenset(args.only if args.only else []))
   pprint.ok('Local repo created in {0}'.format(os.getcwd()))
   if args.repo:
     pprint.ok('Initialized from remote {0}'.format(args.repo))

--- a/gitless/core.py
+++ b/gitless/core.py
@@ -93,7 +93,7 @@ def init_repository(url=None, only=None, exclude=None):
       raise GlError(stderr(e))
 
     # We get all remote branches as well and create local equivalents
-    #Flags: only branches take precedence over exclude branches.
+    # Flags: only branches take precedence over exclude branches.
     repo = Repository()
     remote = repo.remotes['origin']
     for rb in (remote.lookup_branch(bn) for bn in remote.listall_branches()):

--- a/gitless/core.py
+++ b/gitless/core.py
@@ -93,15 +93,15 @@ def init_repository(url=None, only=None, exclude=None):
       raise GlError(stderr(e))
 
     # We get all remote branches as well and create local equivalents
-    #Flags: only branches take precedence over exclude branches. 
+    #Flags: only branches take precedence over exclude branches.
     repo = Repository()
     remote = repo.remotes['origin']
     for rb in (remote.lookup_branch(bn) for bn in remote.listall_branches()):
       if rb.branch_name == 'master':
         continue
-      if only and rb.branch_name not in branches_only:
+      if only and rb.branch_name not in only:
         continue
-      elif not only and exclude and rb.branch_name in branches_exclude:
+      elif not only and exclude and rb.branch_name in exclude:
         continue
       new_b = repo.create_branch(rb.branch_name, rb.head)
       new_b.upstream = rb


### PR DESCRIPTION
Made it so that gl init now takes -o/--only and -e/--exclude commands to perform filtering actions on the branches. The -o flag takes preference over the -e flag; if both exist, only the -o flag will be considered. However, this decision is up for discussion/changes if needed.