### PR TITLE
Enable commands on .gitignore

### DIFF
--- a/gitless/cli/gl.py
+++ b/gitless/cli/gl.py
@@ -67,7 +67,7 @@ def print_help(parser):
       for choice in subparsers_action._choices_actions:
           print('    {:<19} {}'.format(choice.dest, choice.help))
 
-def main():
+def build_parser(subcommands, repo):
   parser = argparse.ArgumentParser(
       description=(
           'Gitless: a version control system built on top of Git.\nMore info, '
@@ -80,12 +80,18 @@ def main():
   subparsers = parser.add_subparsers(title='subcommands', dest='subcmd_name')
   subparsers.required = True
 
+  for sub_cmd in subcommands:
+    sub_cmd.parser(subparsers, repo)
+
+  return parser
+
+def main():
   sub_cmds = [
       gl_track, gl_untrack, gl_status, gl_diff, gl_commit, gl_branch, gl_tag,
       gl_checkout, gl_merge, gl_resolve, gl_fuse, gl_remote, gl_publish,
       gl_switch, gl_init, gl_history]
-  for sub_cmd in sub_cmds:
-    sub_cmd.parser(subparsers, repo)
+
+  parser = build_parser(sub_cmds, repo)
 
   if len(sys.argv) == 1:
     print_help(parser)

--- a/gitless/cli/helpers.py
+++ b/gitless/cli/helpers.py
@@ -112,7 +112,7 @@ class PathProcessor(argparse.Action):
 
   def __call__(self, parser, namespace, paths, option_string=None):
     root = self.repo.root if self.repo else ''
-    repo_dir = self.repo.path[:-1] if self.repo else ''  # strip trailing /
+    repo_dir = self.repo.path if self.repo else '' # Don't strip trailing /
     def process_paths():
       for path in paths:
         path = os.path.abspath(path)
@@ -133,8 +133,6 @@ class PathProcessor(argparse.Action):
         else:
           if not path.startswith(repo_dir):
             yield os.path.relpath(path, root)
-          else:
-            yield path
 
     setattr(namespace, self.dest, process_paths())
 


### PR DESCRIPTION
Allow gitless to track, untrack and resolve on files that start with
.git EXCEPT for the very specific directory at the top level of the repo
.git. For example, `gl track .gitignore` is fine, `gl track .git/HEAD`
is not allowed. Another, `gl track .gitdir/some_file` is allowed, `gl
track .git` will not be allowed.

Fixes #178 .

Made changes to the path processor and wrote unit tests against the path processor. Factored argparser out to a function so unit testing is easier.

The only issue(?) with this approach is that there is no error messaging. Gitless will ALWAYS silently drop the paths and do nothing. Git fatals and reports on the first path if all the paths are under .git/, otherwise it will silently drop the paths under .git/.

E.g.
```
$ git add .git/HEAD
error: invalid path '.git/HEAD'
error: unable to add '.git/HEAD' to index
fatal: adding files failed
$ git add .git/HEAD .git/index
error: invalid path '.git/HEAD'
error: unable to add '.git/HEAD' to index
fatal: adding files failed
$ git add .gitignore .git/HEAD #works with no error message!