### PR TITLE
The Windows console (Win10) needs to be told to accept ANSI color codes

### DIFF
--- a/gitless/cli/gl.py
+++ b/gitless/cli/gl.py
@@ -88,6 +88,12 @@ def build_parser(subcommands, repo):
 
   return parser
 
+def setup_windows_console():
+  if sys.platform == 'win32':
+    import ctypes
+    kernel32 = ctypes.windll.kernel32
+    kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
+
 def main():
   sub_cmds = [
       gl_track, gl_untrack, gl_status, gl_diff, gl_commit, gl_branch, gl_tag,
@@ -105,6 +111,7 @@ def main():
     if args.subcmd_name != 'init' and not repo:
       raise core.NotInRepoError('You are not in a Gitless\'s repository')
 
+    setup_windows_console()
     return SUCCESS if args.func(args, repo) else ERRORS_FOUND
   except KeyboardInterrupt:
     pprint.puts('\n')


### PR DESCRIPTION
Without this, "gl diff" or "gl history" show raw ANSI codes.  This solution only works on Win10 but it's already something.  Partial fix of issue #121 