### PR TITLE
Issues with git track .

### DIFF
--- a/gitless/cli/helpers.py
+++ b/gitless/cli/helpers.py
@@ -134,7 +134,7 @@ class PathProcessor(argparse.Action):
               dirs[:] = []
               continue
             for fp in fps:
-              yield os.path.join(curr_dir_rel, fp)
+              yield fp if curr_dir_rel == '.' else os.path.join(curr_dir_rel, fp)
         else:
           if not path.startswith(normalized_repo_path):
             yield os.path.relpath(path, root)


### PR DESCRIPTION
It seems that when the curr_dir_rel was '.', the generator joined '.' with the filename, but the system wasn't recognizing this file. Changing this so that only the filename is returned in this case seems to work.