### PR TITLE
Added lookup_branches in core to make gl branch -r faster

### DIFF
--- a/gitless/cli/gl_branch.py
+++ b/gitless/cli/gl_branch.py
@@ -118,7 +118,7 @@ def _do_list(repo, list_remote, v=False):
 
   if list_remote:
     for r in sorted(repo.remotes, key=lambda r: r.name):
-      for b in (r.lookup_branch(n) for n in sorted(r.listall_branches())):
+      for b in r.lookup_branches(sorted(r.listall_branches())):
         pprint.item('  {0}'.format(colored.yellow(str(b))))
         if v:
           pprint.item('    ➜ head is {0}'.format(pprint.commit_str(b.head)))

--- a/gitless/cli/gl_branch.py
+++ b/gitless/cli/gl_branch.py
@@ -118,7 +118,7 @@ def _do_list(repo, list_remote, v=False):
 
   if list_remote:
     for r in sorted(repo.remotes, key=lambda r: r.name):
-      for b in r.lookup_branches(sorted(r.listall_branches())):
+      for b in r.lookupall_branches():
         pprint.item('  {0}'.format(colored.yellow(str(b))))
         if v:
           pprint.item('    ➜ head is {0}'.format(pprint.commit_str(b.head)))

--- a/gitless/core.py
+++ b/gitless/core.py
@@ -502,13 +502,15 @@ class Remote(object):
       yield regex.match(head).group(1)
 
   def lookup_branch(self, branch_name):
-    return self.lookup_branches([branch_name])[0]
+    branches = self.lookup_branches([branch_name])
+    if not branches:
+      return None
+    else:
+      return branches[0]
 
   def lookup_branches(self, branch_names):
     all_branches = self.listall_branches()
     branch_names = [branch_name for branch_name in all_branches if branch_name in branch_names]
-    if not branch_names:
-      return None
 
     # The branches exist in the remote
     git.fetch(self.git_remote.name, branch_names)

--- a/gitless/core.py
+++ b/gitless/core.py
@@ -502,24 +502,15 @@ class Remote(object):
       yield regex.match(head).group(1)
 
   def lookup_branch(self, branch_name):
-    if not stdout(git('ls-remote', '--heads', self.name, branch_name)):
-      return None
-    # The branch exists in the remote
-    git.fetch(self.git_remote.name, branch_name)
-    git_branch = self.gl_repo.git_repo.lookup_branch(
-        self.git_remote.name + '/' + branch_name, pygit2.GIT_BRANCH_REMOTE)
-    # Make another check for the branch being None
-    # As observed in issue : https://github.com/sdg-mit/gitless/issues/211
-    if git_branch is None:
-        git.fetch(self.git_remote.name)
-        git_branch = self.gl_repo.git_repo.lookup_branch(
-            self.git_remote.name + '/' + branch_name, pygit2.GIT_BRANCH_REMOTE)
-    return RemoteBranch(git_branch, self.gl_repo)
+    return self.lookup_branches([branch_name])[0]
 
   def lookup_branches(self, branch_names):
-    if not stdout(git('ls-remote', '--heads', self.name, branch_names)):
+    all_branches = self.listall_branches()
+    branch_names = [branch_name for branch_name in all_branches if branch_name in branch_names]
+    if not branch_names:
       return None
-    # The branch exists in the remote
+
+    # The branches exist in the remote
     git.fetch(self.git_remote.name, branch_names)
     remote_branches = []
     for branch_name in branch_names:

--- a/gitless/core.py
+++ b/gitless/core.py
@@ -146,6 +146,8 @@ class Repository(object):
         return self.remotes[remote].lookup_branch(remote_branch).head
       except KeyError:
         pass
+      except AttributeError:
+        pass
     try:
       return self.git_repo.revparse_single(revision)
     except (KeyError, ValueError):
@@ -503,18 +505,13 @@ class Remote(object):
 
   def lookup_branch(self, branch_name):
     branches = self.lookup_branches([branch_name])
-    if not branches:
-      return None
-    else:
-      return branches[0]
+    return branches[0] if branches else None
 
   def lookup_branches(self, branch_names):
-    all_branches = self.listall_branches()
-    branch_names = [branch_name for branch_name in all_branches 
-                                              if branch_name in branch_names]
-
-    # The branches exist in the remote
-    git.fetch(self.git_remote.name, branch_names)
+    try:
+      git.fetch(self.git_remote.name, branch_names)
+    except:
+      return None
     remote_branches = []
     for branch_name in branch_names:
       git_branch = self.gl_repo.git_repo.lookup_branch(
@@ -527,6 +524,9 @@ class Remote(object):
               self.git_remote.name + '/' + branch_name, pygit2.GIT_BRANCH_REMOTE)
       remote_branches.append(RemoteBranch(git_branch, self.gl_repo))
     return remote_branches
+
+  def lookupall_branches(self):
+    return self.lookup_branches(sorted(self.listall_branches()))
 
   # Tag-related methods
 

--- a/gitless/core.py
+++ b/gitless/core.py
@@ -510,7 +510,8 @@ class Remote(object):
 
   def lookup_branches(self, branch_names):
     all_branches = self.listall_branches()
-    branch_names = [branch_name for branch_name in all_branches if branch_name in branch_names]
+    branch_names = [branch_name for branch_name in all_branches 
+                                              if branch_name in branch_names]
 
     # The branches exist in the remote
     git.fetch(self.git_remote.name, branch_names)


### PR DESCRIPTION
In response to open issue #137 , added new lookup_branches in core that does one fetch given all the branch names. This reduced the time of gl branch -r from ~15 seconds to about 2-3 seconds now.