### PR TITLE
Better performance of gl branch -r 

### DIFF
--- a/gitless/cli/gl_branch.py
+++ b/gitless/cli/gl_branch.py
@@ -118,8 +118,10 @@ def _do_list(repo, list_remote, v=False):
 
   if list_remote:
     for r in sorted(repo.remotes, key=lambda r: r.name):
-      for b in r.lookupall_branches():
-        pprint.item('  {0}'.format(colored.yellow(str(b))))
+      branches = r.lookupall_branches() if v else r.listall_branches()
+      b_remote = '' if v else r.name + '/'
+      for b in branches:
+        pprint.item('  {0}'.format(colored.yellow(b_remote + str(b))))
         if v:
           pprint.item('    ➜ head is {0}'.format(pprint.commit_str(b.head)))
 


### PR DESCRIPTION
In the code, we get the remote name and add it before the branch name if the -v flag is not used, as listall_branches() does not have the remote name, just the branch name. However, when the -v flag is used, lookupall_branches() does have the remote name with the branch, so we don't need to add anything. Let me know if this should/could be changed! 